### PR TITLE
Fix webroot in home template

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -15,7 +15,7 @@
     <div class="col-12 col-md-6 col-lg-4 mb-3">
         <div class="card h-100">
             <div class="card-body">
-                <h4 class="card-title"><a href="/aes">AES Encryption</a></h4>
+                <h4 class="card-title"><a href="{{ webroot }}/aes">AES Encryption</a></h4>
                 <p class="card-text">Encrypt and decrypt strings using OpenSSL-compatible AES.</p>
             </div>
         </div>
@@ -23,7 +23,7 @@
     <div class="col-12 col-md-6 col-lg-4 mb-3">
         <div class="card h-100">
             <div class="card-body">
-                <h4 class="card-title"><a href="/rsagen">RSA Key Generator</a></h4>
+                <h4 class="card-title"><a href="{{ webroot }}/rsagen">RSA Key Generator</a></h4>
                 <p class="card-text">Generate an RSA public-private key pair, compatible with OpenSSL.</p>
             </div>
         </div>
@@ -31,7 +31,7 @@
     <div class="col-12 col-md-6 col-lg-4 mb-3">
         <div class="card h-100">
             <div class="card-body">
-                <h4 class="card-title"><a href="/dhe">Diffie-Hellman Exchange</a></h4>
+                <h4 class="card-title"><a href="{{ webroot }}/dhe">Diffie-Hellman Exchange</a></h4>
                 <p class="card-text">Derive a shared secret over an insecure channel.</p>
             </div>
         </div>
@@ -39,7 +39,7 @@
     <div class="col-12 col-md-6 col-lg-4 mb-3">
         <div class="card h-100">
             <div class="card-body">
-                <h4 class="card-title"><a href="/hash">String Hash Calculator</a></h4>
+                <h4 class="card-title"><a href="{{ webroot }}/hash">String Hash Calculator</a></h4>
                 <p class="card-text">Calculate various hashes, like MD5, SHA-256, the SHA-3 family, and others.</p>
             </div>
         </div>
@@ -47,7 +47,7 @@
     <div class="col-12 col-md-6 col-lg-4 mb-3">
         <div class="card h-100">
             <div class="card-body">
-                <h4 class="card-title"><a href="/hmac">String HMAC Calculator</a></h4>
+                <h4 class="card-title"><a href="{{ webroot }}/hmac">String HMAC Calculator</a></h4>
                 <p class="card-text">Like the hash calculator, but with a secret.</p>
             </div>
         </div>
@@ -55,7 +55,7 @@
     <div class="col-12 col-md-6 col-lg-4 mb-3">
         <div class="card h-100">
             <div class="card-body">
-                <h4 class="card-title"><a href="/otp">TOTP Calculator</a></h4>
+                <h4 class="card-title"><a href="{{ webroot }}/otp">TOTP Calculator</a></h4>
                 <p class="card-text">RFC 6238-compatible time-based one-time password calculator and QR code generator, compatible with Google Authenticator, Authy, and others.</p>
             </div>
         </div>


### PR DESCRIPTION
When hosting CryptoTools yourself under non-root, things generally work fine, only the links on the start page are wrong.

This fixes that.

You also need to adjust the routers base-path:
https://github.com/khicks/CryptoTools.net/blob/ff5c3a80fc0397f41dab8a25d572e1c936b84981/index.php#L7

for example to 

```php
 $router->setBasePath('/cryptotools'); 
```